### PR TITLE
Change CTA in site header

### DIFF
--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -1,7 +1,7 @@
 <header class="site-header">
   <nav class="top-nav d-flex light-blue align-items-center">
     <a href="{{ '/' | relative_url }}"><img src="{{ 'assets/img/judo-dev-portal-logo.svg' | relative_url }}" width="302"></a>
-    <a href="https://www.judo.app/signup" class="btn btn-arrow">Sign Up</a>
+  <a href="https://apps.apple.com/app/apple-store/id1564578427?pt=75075800&ct=Marketing%20Site&mt=8" class="btn btn-arrow">Get the Mac App</a>
     <button class="navbar-toggler" type="button" id="hamburger" title="Toggle Navigation" aria-label="Toggle navigation">
       <span class="menu-toggle">
         <span></span>

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -36,7 +36,7 @@
         <li><a href="{{ ordered_ios_pages.first.url | relative_url }}" {% if page.platform == "iOS" %}class="active"{% endif %}>iOS SDK</a></li>
         {% assign ordered_android_pages = site.android | sort:"step" %}
         <li><a href="{{ ordered_android_pages.first.url | relative_url }}" {% if page.platform == "Android" %}class="active"{% endif %}>Android SDK</a></li>
-        <li><a href="https://www.judo.app/signup" class="btn btn-arrow">Get Started</a></li>
+        <li><a href="https://apps.apple.com/app/apple-store/id1564578427?pt=75075800&ct=Marketing%20Site&mt=8" class="btn btn-arrow">Get the Mac App</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Changed "Sign Up" in the site header to be "Get the Mac App" to be consistent across the Judo sites.